### PR TITLE
Implementar endpoint /salud y script de ejecución en Sprint 1

### DIFF
--- a/out/salud_response.txt
+++ b/out/salud_response.txt
@@ -1,0 +1,6 @@
+HTTP/1.0 200 OK
+Server: BaseHTTP/0.6 Python/3.12.3
+Date: Tue, 30 Sep 2025 04:37:54 GMT
+Content-type: text/plain
+
+OK

--- a/src/iniciar-servicio.sh
+++ b/src/iniciar-servicio.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Variables
+PORT="${PORT:-8080}"
+
+# Limpiar procesos previos
+trap "echo 'Cerrando servidor...'; exit 0" SIGINT SIGTERM
+
+# Ejecutar servicio
+echo "Iniciando servicio en puerto $PORT..."
+python3 src/servicio.py

--- a/src/servicio.py
+++ b/src/servicio.py
@@ -1,0 +1,20 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
+
+PORT = int(os.getenv("PORT", "8080"))
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/salud":
+            self.send_response(200)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+if __name__ == "__main__":
+    with HTTPServer(("", PORT), Handler) as httpd:
+        print(f"Servidor escuchando en puerto {PORT}")
+        httpd.serve_forever()


### PR DESCRIPTION
### ¿Qué se hizo?
- Implementación del endpoint `/salud` en Python que responde con código **200 OK**.
- Creación del script `run.sh` para ejecutar el servicio.
- Evidencia guardada en `out/salud_response.txt` mostrando respuesta HTTP.

### ¿Por qué?
Este cambio corresponde al Sprint 1 del Proyecto 5, donde se debe exponer `/salud`, configurar el servicio con variables de entorno y dejar las primeras evidencias.

### ¿Cómo?
- El servicio se ejecuta con:
  ```bash
  export PORT=8080
  ./src/run.sh