### PR TITLE
Implementar endpoint /config con lista blanca y validaciones (Sprint 2)

### DIFF
--- a/out/config_response.txt
+++ b/out/config_response.txt
@@ -1,0 +1,12 @@
+HTTP/1.0 200 OK
+Server: BaseHTTP/0.6 Python/3.12.3
+Date: Thu, 02 Oct 2025 17:48:14 GMT
+Content-type: application/json
+
+{
+  "PORT": "8080",
+  "RELEASE": "v1.0.0",
+  "HOST": "localhost",
+  "DEBUG": "true",
+  "LOG_LEVEL": "INFO"
+}

--- a/out/config_response.txt
+++ b/out/config_response.txt
@@ -1,12 +1,10 @@
 HTTP/1.0 200 OK
 Server: BaseHTTP/0.6 Python/3.12.3
-Date: Thu, 02 Oct 2025 17:48:14 GMT
-Content-type: application/json
+Date: Sat, 04 Oct 2025 01:16:44 GMT
+Content-type: text/plain
 
 {
   "PORT": "8080",
   "RELEASE": "v1.0.0",
-  "HOST": "localhost",
-  "DEBUG": "true",
-  "LOG_LEVEL": "INFO"
+  "DEBUG": "True"
 }

--- a/src/servicio.py
+++ b/src/servicio.py
@@ -1,8 +1,9 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import os
+import json
 
 PORT = int(os.getenv("PORT", "8080"))
-
+WHITELIST = ["PORT", "RELEASE", "HOST", "DEBUG", "LOG_LEVEL"]
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/salud":
@@ -10,11 +11,42 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-type", "text/plain")
             self.end_headers()
             self.wfile.write(b"OK")
+        
+        elif self.path == "/config":
+            # Validar variables requeridas
+            if os.getenv("PORT") is None:
+                self.send_response(500)
+                self.send_header("Content-type", "text/plain")
+                self.end_headers()
+                self.wfile.write("ERROR: Variable requerida PORT no definida".encode())
+                return
+
+            # Filtrar variables de la lista blanca
+            config = {key: os.getenv(key) for key in WHITELIST if os.getenv(key)}
+
+            # Determinar formato
+            formato = os.getenv("FORMATO_SALIDA", "json").lower()
+            if formato == "texto":
+                body = "\n".join(f"{k}={v}" for k, v in config.items())
+                self.send_response(200)
+                self.send_header("Content-type", "text/plain")
+                self.end_headers()
+                self.wfile.write(body.encode())
+            else:  # JSON por defecto
+                body = json.dumps(config, indent=2)
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(body.encode())
+
         else:
             self.send_response(404)
             self.end_headers()
 
 if __name__ == "__main__":
-    with HTTPServer(("", PORT), Handler) as httpd:
-        print(f"Servidor escuchando en puerto {PORT}")
-        httpd.serve_forever()
+    try:
+        with HTTPServer(("", PORT), Handler) as httpd:
+            print(f"Servidor escuchando en puerto {PORT}")
+            httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("")

--- a/src/servicio.py
+++ b/src/servicio.py
@@ -1,9 +1,9 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import os
-import json
+import subprocess
 
 PORT = int(os.getenv("PORT", "8080"))
-WHITELIST = ["PORT", "RELEASE", "HOST", "DEBUG", "LOG_LEVEL"]
+
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/salud":
@@ -13,31 +13,34 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(b"OK")
         
         elif self.path == "/config":
-            # Validar variables requeridas
-            if os.getenv("PORT") is None:
+            try:
+                # DELEGAR TODA LA LÓGICA A TU SCRIPT BASH
+                result = subprocess.run(
+                    ['./src/generar-config.sh'],
+                    capture_output=True, #stdout y stderror
+                    text=True,
+                    timeout=5,
+                    env=os.environ  # Pasar todas las variables de entorno
+                )
+                
+                if result.returncode == 0:
+                    # Script Bash retorna la configuración directamente
+                    self.send_response(200)
+                    self.send_header("Content-type", "text/plain")
+                    self.end_headers()
+                    self.wfile.write(result.stdout.encode())
+                else:
+                    # Error manejado por Bash
+                    self.send_response(500)
+                    self.send_header("Content-type", "text/plain") 
+                    self.end_headers()
+                    self.wfile.write(result.stderr.encode())
+                    
+            except Exception as e:
                 self.send_response(500)
                 self.send_header("Content-type", "text/plain")
                 self.end_headers()
-                self.wfile.write("ERROR: Variable requerida PORT no definida".encode())
-                return
-
-            # Filtrar variables de la lista blanca
-            config = {key: os.getenv(key) for key in WHITELIST if os.getenv(key)}
-
-            # Determinar formato
-            formato = os.getenv("FORMATO_SALIDA", "json").lower()
-            if formato == "texto":
-                body = "\n".join(f"{k}={v}" for k, v in config.items())
-                self.send_response(200)
-                self.send_header("Content-type", "text/plain")
-                self.end_headers()
-                self.wfile.write(body.encode())
-            else:  # JSON por defecto
-                body = json.dumps(config, indent=2)
-                self.send_response(200)
-                self.send_header("Content-type", "application/json")
-                self.end_headers()
-                self.wfile.write(body.encode())
+                self.wfile.write(f"Error ejecutando configuración: {str(e)}".encode())
 
         else:
             self.send_response(404)


### PR DESCRIPTION
### Descripción  
- Añadido endpoint `/config` en `servicio.py`, delegando lógica a `generar-config.sh`.  
- Implementada lista blanca para exponer solo variables permitidas.  
- Manejo de errores con respuestas **500** en casos fallidos.  
- Evidencias registradas en `out/config_response.txt`.  

### Checklist  
- [ ] `/config` responde con **200** y formato válido  
- [ ] Solo variables permitidas en salida  
- [ ] Errores devuelven **500** con mensaje claro  
- [ ] Evidencias actualizadas en `out/`  
- [ ] Commits en español y descriptivos  
- [ ] Documentación/bitácora actualizada  