### PR TITLE
Corregir ejecución de scripts bash en Windows

### DIFF
--- a/src/servicio.py
+++ b/src/servicio.py
@@ -16,7 +16,7 @@ class Handler(BaseHTTPRequestHandler):
             try:
                 # DELEGAR TODA LA LÓGICA A TU SCRIPT BASH
                 result = subprocess.run(
-                    ['./src/generar-config.sh'],
+                    ['bash', './src/generar-config.sh'],
                     capture_output=True, #stdout y stderror
                     text=True,
                     timeout=5,


### PR DESCRIPTION
Corregida la ejecución de scripts Bash en servicio.py para Windows

Asegura la compatibilidad de `subprocess.run` en entornos Windows (como MINGW64) al especificar explícitamente el intérprete `bash` para los scripts `.sh`.